### PR TITLE
RAC3: Missing Skill Point Key Error Fix

### DIFF
--- a/worlds/rac3/client/client.py
+++ b/worlds/rac3/client/client.py
@@ -322,7 +322,7 @@ async def pcsx2_sync_task(ctx: Rac3Context):
                         connection_retry_attempts += 1
 
                     retry_wait = connection_retry_attempts * 10
-                    logger.warning(f'Could not connect to RaC3! Will retry connection in {retry_wait} seconds...')
+                    logger.warning(f'Could not connect to RaC3! Will retry connection in {retry_wait} seconds...\nPlease check your PINE settings both global and game specific, and restart PCSX2 if you changed them.')
                     await sleep(retry_wait)
                 else:
                     connection_retry_attempts = 0

--- a/worlds/rac3/regions.py
+++ b/worlds/rac3/regions.py
@@ -526,7 +526,7 @@ def should_skip_location(data: RAC3LOCATIONDATA, options: type[RaC3Options]) -> 
                 elif not all_skill_points and loc == RAC3TROPHY.PHOENIX_SKILL_MASTER:
                     return True
             case RAC3TAG.SKILLPOINT:
-                if not options.skill_points[SKILLPOINT_LOCATION_TO_NAME[loc]]:
+                if not options.skill_points.get(SKILLPOINT_LOCATION_TO_NAME[loc], False):
                     return True  # Skips the skill points which the player didn't choose
             case RAC3TAG.T_BOLT:
                 if options.titanium_bolts.value == 0:


### PR DESCRIPTION
Someone used Option Creator to remove all skill points they didn't want in the pool and that caused a KeyError when connecting. Someone also reported that they were unsure of what to do when the client fails to connect to the emulator, so this PR also adds more messaging for when that happens.