### PR TITLE
RAC3: Fix vehicle deathlink messages

### DIFF
--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -1108,7 +1108,6 @@ class Rac3Interface(GameInterface):
         if self.vehicle or (current_time - self.last_in_vehicle_time < 1 and self.action == 0x39):
             self.last_in_vehicle_time = current_time
             
-
     def pause_check(self):
         if self.planet not in RAC3_REGION_DATA_TABLE.keys():
             # Unknown planet, assume paused to be safe

--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -256,6 +256,7 @@ class Rac3Interface(GameInterface):
     ship_slot_limit: int = 0
     one_hp_challenge: dict[str, bool] = None
     pda_vendor: int = 0
+    last_in_vehicle_time: float = 0.0
 
     # Called at once when client started
     def init(self):
@@ -286,6 +287,7 @@ class Rac3Interface(GameInterface):
         self.inside_hacker_puzzle = self._read8(RAC3STATUS.HELD_ITEM) == RAC3_ITEM_DATA_TABLE[RAC3ITEM.HACKER].ID
         self.message_display = bool(self._read_float(self._read32(RAC3MESSAGEBOX.VISIBLE_POINTER)))
 
+        self.vehicle_check()
         self.pause_check()
         if self.self_respawning:
             if not self.is_reloading:
@@ -1083,7 +1085,7 @@ class Rac3Interface(GameInterface):
         """Detects if the game is currently being reloaded, and updates death data"""
         if self.is_reloading and not self.reloading_handled and not self.self_respawning:
             self.last_death_state = self.action
-            self.died_in_vehicle = bool(self._read8(RAC3STATUS.IN_VEHICLE))
+            self.died_in_vehicle = time.time() - self.last_in_vehicle_time < 1.5
             self.reloading_handled = True
             logger.debug(f'{self.player_type} is Respawning, death state: {self.last_death_state},'
                          f' death count: {self.last_death_count}, in vehicle? {self.died_in_vehicle}')
@@ -1096,6 +1098,20 @@ class Rac3Interface(GameInterface):
                          f' {self.has_died}')
         else:
             self.has_died = False
+    
+    def vehicle_check(self):
+        """
+        Updates the last_in_vehicle_time when the player is in a vehicle.
+        Used to detect if the player died while in a vehicle for deathlink.
+        """
+        current_time = time.time()
+        if self.vehicle:
+            self.last_in_vehicle_time = current_time
+        
+        # Special case for vehicles that eject you and kill you after some time
+        if current_time - self.last_in_vehicle_time < 1 and self.action == 0x39:
+            self.last_in_vehicle_time = current_time
+            
 
     def pause_check(self):
         if self.planet not in RAC3_REGION_DATA_TABLE.keys():

--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -1098,7 +1098,7 @@ class Rac3Interface(GameInterface):
                          f' {self.has_died}')
         else:
             self.has_died = False
-    
+
     def vehicle_check(self):
         """
         Updates the last_in_vehicle_time when the player is in a vehicle.

--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -1107,7 +1107,7 @@ class Rac3Interface(GameInterface):
         current_time = time.time()
         if self.vehicle or (current_time - self.last_in_vehicle_time < 1 and self.action == 0x39):
             self.last_in_vehicle_time = current_time
-            
+
     def pause_check(self):
         if self.planet not in RAC3_REGION_DATA_TABLE.keys():
             # Unknown planet, assume paused to be safe

--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -1104,12 +1104,8 @@ class Rac3Interface(GameInterface):
         Updates the last_in_vehicle_time when the player is in a vehicle.
         Used to detect if the player died while in a vehicle for deathlink.
         """
-        current_time = time.time()
-        if self.vehicle:
-            self.last_in_vehicle_time = current_time
-        
-        # Special case for vehicles that eject you and kill you after some time
-        if current_time - self.last_in_vehicle_time < 1 and self.action == 0x39:
+        current_time = time.time()        
+        if self.vehicle or (current_time - self.last_in_vehicle_time < 1 and self.action == 0x39):
             self.last_in_vehicle_time = current_time
             
 

--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -1104,7 +1104,7 @@ class Rac3Interface(GameInterface):
         Updates the last_in_vehicle_time when the player is in a vehicle.
         Used to detect if the player died while in a vehicle for deathlink.
         """
-        current_time = time.time()        
+        current_time = time.time()
         if self.vehicle or (current_time - self.last_in_vehicle_time < 1 and self.action == 0x39):
             self.last_in_vehicle_time = current_time
             

--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -351,8 +351,11 @@ class Rac3Interface(GameInterface):
     def tyhrranosis_fix(self):
         self._write8(RAC3STATUS.ROBONOIDS, 0)
 
-    def item_received(self, item_code: int, our_name: Optional[str], other_player: Optional[str], location: Optional[
-            int]):
+    def item_received(self,
+                      item_code: int,
+                      our_name: Optional[str],
+                      other_player: Optional[str],
+                      location: Optional[int]):
         name = PROG_TO_NAME_DICT.get(ITEM_FROM_AP_CODE[item_code], ITEM_FROM_AP_CODE[item_code])
         if other_player is not None:
             classification = RAC3_ITEM_DATA_TABLE[name].AP_CLASSIFICATION
@@ -988,8 +991,9 @@ class Rac3Interface(GameInterface):
                 if self._read8(RAC3STATUS.HEALTH) > 1:
                     self._write8(RAC3STATUS.HEALTH, 1)
                     self._write8(RAC3STATUS.NANOPAK_HEALTH, 0)
-                if (character == RAC3PLAYERTYPE.RATCHET and self.planet == RAC3REGION.ANNIHILATION_NATION and not
-                        self.pause_state):
+                if (character == RAC3PLAYERTYPE.RATCHET
+                        and self.planet == RAC3REGION.ANNIHILATION_NATION
+                        and not self.pause_state):
                     # Patch out sleeping gas health reduction to prevent death
                     self._write32(RAC3INSTRUCTION.NATION_SLEEP_GAS_HEALTH_UPDATE, 0x24420000)  # addiu v0,v0,0x0
                     # Patch out health refill to prevent auto losing One Hit Wonder challenge
@@ -1266,8 +1270,12 @@ class Rac3Interface(GameInterface):
         """
         return not (self.pause_menu ^ paused) and (self.inputs & check) == check
 
-    def messagebox(self, msg_list: list[bytes], color_bytes_count: int, longest_line_length: int, box_theme: int =
-                   RAC3BOXTHEME.DEFAULT, _time: int = 0x168) -> None:
+    def messagebox(self,
+                   msg_list: list[bytes],
+                   color_bytes_count: int,
+                   longest_line_length: int,
+                   box_theme: int = RAC3BOXTHEME.DEFAULT,
+                   _time: int = 0x168) -> None:
         if _time < 0:
             _time = 0
         # real overflow cap is actually about 248, but we don't need that long messages

--- a/worlds/rac3/client/interface.py
+++ b/worlds/rac3/client/interface.py
@@ -352,7 +352,7 @@ class Rac3Interface(GameInterface):
         self._write8(RAC3STATUS.ROBONOIDS, 0)
 
     def item_received(self, item_code: int, our_name: Optional[str], other_player: Optional[str], location: Optional[
-        int]):
+            int]):
         name = PROG_TO_NAME_DICT.get(ITEM_FROM_AP_CODE[item_code], ITEM_FROM_AP_CODE[item_code])
         if other_player is not None:
             classification = RAC3_ITEM_DATA_TABLE[name].AP_CLASSIFICATION
@@ -530,9 +530,9 @@ class Rac3Interface(GameInterface):
         logger.debug(f'UnlockItem dict:{self.UnlockItem.keys()}')
 
         # Proc options
-        ### Bolt and XPMultiplier
+        # Bolt and XPMultiplier
         self.boltAndXPMultiplierValue = int(self.boltAndXPMultiplier)
-        ### EnableWeaponLevelAsItem: if enabled, EXP disabler is running.
+        # EnableWeaponLevelAsItem: if enabled, EXP disabler is running.
 
     # Address conversion from str to int(with US to JP)
     @staticmethod
@@ -706,7 +706,7 @@ class Rac3Interface(GameInterface):
                 or self._read16(RAC3STATUS.FALL_TIMER) == 1):
             return False
         return True
-    
+
     def near_pda_vendor(self) -> bool:
         if self.planet == RAC3REGION.QWARKS_HIDEOUT and self.distance_to_moby(self.pda_vendor) < 12.0:
             return True
@@ -989,7 +989,7 @@ class Rac3Interface(GameInterface):
                     self._write8(RAC3STATUS.HEALTH, 1)
                     self._write8(RAC3STATUS.NANOPAK_HEALTH, 0)
                 if (character == RAC3PLAYERTYPE.RATCHET and self.planet == RAC3REGION.ANNIHILATION_NATION and not
-                self.pause_state):
+                        self.pause_state):
                     # Patch out sleeping gas health reduction to prevent death
                     self._write32(RAC3INSTRUCTION.NATION_SLEEP_GAS_HEALTH_UPDATE, 0x24420000)  # addiu v0,v0,0x0
                     # Patch out health refill to prevent auto losing One Hit Wonder challenge
@@ -1267,7 +1267,7 @@ class Rac3Interface(GameInterface):
         return not (self.pause_menu ^ paused) and (self.inputs & check) == check
 
     def messagebox(self, msg_list: list[bytes], color_bytes_count: int, longest_line_length: int, box_theme: int =
-    RAC3BOXTHEME.DEFAULT, _time: int = 0x168) -> None:
+                   RAC3BOXTHEME.DEFAULT, _time: int = 0x168) -> None:
         if _time < 0:
             _time = 0
         # real overflow cap is actually about 248, but we don't need that long messages


### PR DESCRIPTION
Use system time to track when you were last in a vehicle to get around vehicle pointer becoming 0 during reload