### PR TITLE
RAC3: Fix VR Generation Errors

### DIFF
--- a/worlds/rac3/constants/data/item.py
+++ b/worlds/rac3/constants/data/item.py
@@ -375,7 +375,8 @@ RAC3_ITEM_DATA_TABLE: dict[str, RAC3ITEMDATA] = {
     RAC3ITEM.PROGRESSIVE_BOUNCER: RAC3ITEMDATA.construct_rac2_prog(0xCD, ItemClassification.useful),
     RAC3ITEM.PROGRESSIVE_MINI_TURRET: RAC3ITEMDATA.construct_rac2_prog(0xCE, ItemClassification.useful),
     RAC3ITEM.PROGRESSIVE_SHIELD_CHARGER: RAC3ITEMDATA.construct_rac2_prog(0xCF, ItemClassification.useful),
-    RAC3ITEM.PROGRESSIVE_SHOCK_BLASTER: RAC3ITEMDATA.construct_weapon_prog(0xD0, ItemClassification.useful),
+    RAC3ITEM.PROGRESSIVE_SHOCK_BLASTER: 
+        RAC3ITEMDATA.construct_weapon_prog(0xD0, ItemClassification.progression_skip_balancing),
     RAC3ITEM.PROGRESSIVE_N60_STORM: RAC3ITEMDATA.construct_weapon_prog(0xD1, ItemClassification.useful),
     RAC3ITEM.PROGRESSIVE_INFECTOR:
         RAC3ITEMDATA.construct_weapon_prog(0xD2, ItemClassification.progression_skip_balancing),

--- a/worlds/rac3/rules.py
+++ b/worlds/rac3/rules.py
@@ -139,16 +139,16 @@ def set_rules(world: "RaC3World"):
         RAC3LOCATION.PHOENIX_VR_90_SECOND:
             lambda state: state.can_reach_location(RAC3LOCATION.PHOENIX_VR_SPEED_ROUND, player=world.player),
         RAC3LOCATION.PHOENIX_VR_SHOCKER:
-            lambda state: state.has_any([RAC3ITEM.SHOCK_BLASTER, RAC3ITEM.PROGRESSIVE_SHOCK_BLASTER], world.player)
+            lambda state: state.has_any([RAC3ITEM.SHOCK_BLASTER, RAC3ITEM.PROGRESSIVE_SHOCK_BLASTER], player=world.player)
                           and state.can_reach_location(RAC3LOCATION.PHOENIX_VR_D_L_D, player=world.player),
         RAC3LOCATION.PHOENIX_VR_WRENCH:
             lambda state: state.can_reach_location(RAC3LOCATION.PHOENIX_VR_SHOCKER, player=world.player),
         RAC3TBOLT.PHOENIX_VR_NERVES:
             lambda state: state.can_reach_location(RAC3LOCATION.PHOENIX_VR_WRENCH, player=world.player)
-                          and state.can_reach_location(RAC3LOCATION.PHOENIX_VR_90_SECOND),
+                          and state.can_reach_location(RAC3LOCATION.PHOENIX_VR_90_SECOND, player=world.player),
         RAC3LOCATION.PHOENIX_VR_NERVES:
             lambda state: state.can_reach_location(RAC3LOCATION.PHOENIX_VR_WRENCH, player=world.player)
-                          and state.can_reach_location(RAC3LOCATION.PHOENIX_VR_90_SECOND),
+                          and state.can_reach_location(RAC3LOCATION.PHOENIX_VR_90_SECOND, player=world.player),
         RAC3TBOLT.PHOENIX_VR_TRAINING:
             lambda state: state.can_reach(RAC3REGION.TYHRRANOSIS, player=world.player)
                           and state.has_all([RAC3ITEM.HACKER, RAC3ITEM.HYPERSHOT], player=world.player),


### PR DESCRIPTION
Fix progressive shock blaster not marked as progression item causing VR logic to cause gen failures past Phoenix: VR: The Shocker
