### PR TITLE
RAC3: Fix multiple messages getting queued for a single check

### DIFF
--- a/worlds/rac3/client/callbacks.py
+++ b/worlds/rac3/client/callbacks.py
@@ -98,7 +98,7 @@ async def handle_checked_locations(ctx: 'Context') -> None:
     # logger.info(f"{ctx.server_locations}")
     new_checks = []
     for ap_code in ctx.server_locations:
-        if ap_code in ctx.checked_locations:
+        if ap_code in ctx.checked_locations | ctx.locations_checked:
             continue
         if ctx.game_interface.is_location_checked(ap_code):
             new_checks.append(ap_code)
@@ -106,7 +106,7 @@ async def handle_checked_locations(ctx: 'Context') -> None:
     if new_checks:
         real_checks = list(await ctx.check_locations(new_checks))
         ctx.locations_checked.update(real_checks)
-        for location in set(real_checks):
+        for location in real_checks:
             net_item = ctx.locations_info.get(location, None)
             if net_item is not None and net_item.player != ctx.slot:
                 item_to_player_names = get_rich_item_name(ctx, net_item, True)

--- a/worlds/rac3/client/callbacks.py
+++ b/worlds/rac3/client/callbacks.py
@@ -106,7 +106,7 @@ async def handle_checked_locations(ctx: 'Context') -> None:
     if new_checks:
         real_checks = list(await ctx.check_locations(new_checks))
         ctx.locations_checked.update(real_checks)
-        for location in real_checks:
+        for location in set(real_checks):
             net_item = ctx.locations_info.get(location, None)
             if net_item is not None and net_item.player != ctx.slot:
                 item_to_player_names = get_rich_item_name(ctx, net_item, True)


### PR DESCRIPTION
Attempts to fix multiple messages getting queued in the notification queue for a single check by ensuring the location list only contains unique elements.