### PR TITLE
RAC3: Remove impossible starting planets

### DIFF
--- a/worlds/rac3/items.py
+++ b/worlds/rac3/items.py
@@ -162,8 +162,7 @@ def starting_weapons(world: "RaC3World") -> list[str]:
 
 def starting_planets(world: "RaC3World") -> list[str]:
     planet_list: list[str] = [infobot for infobot in infobot_data.keys() if infobot not in world.preplaced_items]
-    if RAC3ITEM.MUSEUM in planet_list:
-        planet_list.remove(RAC3ITEM.MUSEUM)
+    planet_list = remove_dead_starting_planets(world, planet_list)
     if len(planet_list) > 1:  # [Phoenix], [Florana], or [Other]
         world.random.shuffle(planet_list)
         if world.options.intro_skip.value:
@@ -190,3 +189,31 @@ def starting_planets(world: "RaC3World") -> list[str]:
             else:
                 planet_list = planet_list[:2]  # [Other, Other]
     return planet_list
+
+def remove_dead_starting_planets(world: "RaC3World", current_planet_list: list[str]) -> list[str]:
+    """Removes any starting planets that are unreachable from Veldin"""
+    if RAC3ITEM.MUSEUM in current_planet_list:
+        current_planet_list.remove(RAC3ITEM.MUSEUM)
+    if RAC3ITEM.OBANI_DRACO in current_planet_list:
+        current_planet_list.remove(RAC3ITEM.OBANI_DRACO)
+    if RAC3ITEM.OBANI_GEMINI in current_planet_list:
+        current_planet_list.remove(RAC3ITEM.OBANI_GEMINI)
+    if RAC3ITEM.QWARKS_HIDEOUT in current_planet_list:
+        current_planet_list.remove(RAC3ITEM.QWARKS_HIDEOUT)
+    if RAC3ITEM.COMMAND_CENTER in current_planet_list:
+        current_planet_list.remove(RAC3ITEM.COMMAND_CENTER)
+    if RAC3ITEM.HOLOSTAR_STUDIOS in current_planet_list:
+        current_planet_list.remove(RAC3ITEM.HOLOSTAR_STUDIOS)
+
+    # If Rangers are disabled, Aridia and Blackwater City are unreachable
+    if world.options.rangers.value == 0:
+        to_remove = {RAC3ITEM.ARIDIA, RAC3ITEM.BLACKWATER_CITY}
+        current_planet_list = [planet for planet in current_planet_list if planet not in to_remove]
+
+    # If no Arena challenges are locations or only the second half is,
+    # Annihilation Nation is unreachable from the start
+    if world.options.arena.value == 0 or world.options.arena.value == 2:
+        to_remove = {RAC3ITEM.ANNIHILATION_NATION}
+        current_planet_list = [planet for planet in current_planet_list if planet not in to_remove]
+
+    return current_planet_list

--- a/worlds/rac3/items.py
+++ b/worlds/rac3/items.py
@@ -190,29 +190,31 @@ def starting_planets(world: "RaC3World") -> list[str]:
                 planet_list = planet_list[:2]  # [Other, Other]
     return planet_list
 
+# TODO: Rework this function during logic overhaul
 def remove_dead_starting_planets(world: "RaC3World", current_planet_list: list[str]) -> list[str]:
     """Removes any starting planets that are unreachable from Veldin"""
-    if RAC3ITEM.MUSEUM in current_planet_list:
-        current_planet_list.remove(RAC3ITEM.MUSEUM)
-    if RAC3ITEM.OBANI_DRACO in current_planet_list:
-        current_planet_list.remove(RAC3ITEM.OBANI_DRACO)
-    if RAC3ITEM.OBANI_GEMINI in current_planet_list:
-        current_planet_list.remove(RAC3ITEM.OBANI_GEMINI)
-    if RAC3ITEM.QWARKS_HIDEOUT in current_planet_list:
-        current_planet_list.remove(RAC3ITEM.QWARKS_HIDEOUT)
-    if RAC3ITEM.COMMAND_CENTER in current_planet_list:
-        current_planet_list.remove(RAC3ITEM.COMMAND_CENTER)
-    if RAC3ITEM.HOLOSTAR_STUDIOS in current_planet_list:
-        current_planet_list.remove(RAC3ITEM.HOLOSTAR_STUDIOS)
+    # Remove unreachable planets in a single loop
+    unreachable = [
+        RAC3ITEM.MUSEUM,
+        RAC3ITEM.OBANI_DRACO,
+        RAC3ITEM.OBANI_GEMINI,
+        RAC3ITEM.QWARKS_HIDEOUT,
+        RAC3ITEM.COMMAND_CENTER,
+        RAC3ITEM.HOLOSTAR_STUDIOS
+    ]
+    current_planet_list = [planet for planet in current_planet_list if planet not in unreachable]
 
     # If Rangers are disabled, Aridia and Blackwater City are unreachable
     if world.options.rangers.value == 0:
-        to_remove = {RAC3ITEM.ARIDIA, RAC3ITEM.BLACKWATER_CITY}
+        to_remove = {RAC3ITEM.BLACKWATER_CITY}
+        if world.options.weapon_vendors.value == 0:
+            to_remove.add(RAC3ITEM.ARIDIA)
+            
         current_planet_list = [planet for planet in current_planet_list if planet not in to_remove]
 
     # If no Arena challenges are locations or only the second half is,
     # Annihilation Nation is unreachable from the start
-    if world.options.arena.value == 0 or world.options.arena.value == 2:
+    if (world.options.arena.value == 0 or world.options.arena.value == 2) and world.options.weapon_vendors.value == 0:
         to_remove = {RAC3ITEM.ANNIHILATION_NATION}
         current_planet_list = [planet for planet in current_planet_list if planet not in to_remove]
 

--- a/worlds/rac3/regions.py
+++ b/worlds/rac3/regions.py
@@ -602,6 +602,6 @@ def should_skip_location(data: RAC3LOCATIONDATA, options: type[RaC3Options]) -> 
                     return True  # Skips every weapon vendor checks except the Veldin ones
             # Add more conditions here if needed in the future
             case RAC3TAG.ONE_HP_UNSTABLE:
-                if options.one_hp_challenge.value[RAC3PLAYERTYPE.RATCHET]:
+                if options.one_hp_challenge.value.get(RAC3PLAYERTYPE.RATCHET, False):
                     return True  # Skip all unstable locations in One HP Challenge
     return False

--- a/worlds/rac3/world.py
+++ b/worlds/rac3/world.py
@@ -120,18 +120,29 @@ class RaC3World(World):
         self.multiworld.itempool.extend(itempool)
         location_count = len(self.multiworld.get_unfilled_locations(self.player))
         item_count = len(itempool)
+        excluded_count = self.get_excluded_count()
+        if excluded_count > location_count - item_count:
+            raise OptionError("Too many locations have been excluded, not enough locations remain to place all items.")
         if location_count - item_count >= 0:
             filler = [self.create_filler() for _ in range(location_count - item_count)]
             self.multiworld.itempool.extend(filler)
         else:
             self.handle_not_enough_locations(item_count - location_count)
 
+    def get_excluded_count(self) -> int:
+        """Get the number of unique excluded locations for this player"""
+        excluded_options = self.options.exclude_locations.value
+        excluded_locations = set()
+        for option in excluded_options:
+            if option in location_groups:
+                excluded_locations.update(location_groups[option])
+            else:
+                excluded_locations.add(option)
+        return len(excluded_locations)
+
     def handle_not_enough_locations(self, count):
         """Check the available location and items counts, raise OptionErrors to warn the player of too few locations"""
-        try:
-            excluded_count = len(self.multiworld.exclude_locations[self.player].value)
-        except AttributeError:
-            excluded_count = 0
+        excluded_count = self.get_excluded_count()
         option_list: list[str] = []
         if self.options.skill_points.value == 0:
             option_list.append(RAC3OPTION.SKILL_POINTS)


### PR DESCRIPTION
Remove planets from starting planets if options removed their itemless reachable locations