### PR TITLE
Post v0.5.0 fixes

### DIFF
--- a/worlds/rac3/options/scout_vendors_options.py
+++ b/worlds/rac3/options/scout_vendors_options.py
@@ -10,6 +10,7 @@ class ScoutVendors(OptionCounter):
     Ship: Ship vendor sends out hints.
     Weapon: Gadgetron vendors and Slim Cognito's shop send out hints.
 
+    The vendors will always show the item names inside them in game, regardless of this option.
     1 = Enabled, 0 = Disabled
     """
     min = 0

--- a/worlds/rac3/rac3options.py
+++ b/worlds/rac3/rac3options.py
@@ -19,7 +19,7 @@ from worlds.rac3.options.one_hp_options import OneHpChallenge
 from worlds.rac3.options.prog_weapons_options import EnableProgressiveWeapons
 from worlds.rac3.options.rangers_options import Rangers
 from worlds.rac3.options.ratchet_skins_options import RatchetSkin
-from worlds.rac3.options.scout_vendors import ScoutVendors
+from worlds.rac3.options.scout_vendors_options import ScoutVendors
 from worlds.rac3.options.sewer_limitation_options import SewerLimitation
 from worlds.rac3.options.sewer_options import SewerCrystals
 from worlds.rac3.options.ship_nose_options import ShipNose


### PR DESCRIPTION
Scout vendors file name was incosistent compared to other option files and Scout Vendors yaml description got a bit of clarification.