### PR TITLE
Hotfix: Fix weapon level and exp getting reset when it shouldnt

### DIFF
--- a/worlds/rac3/client/rac3_interface.py
+++ b/worlds/rac3/client/rac3_interface.py
@@ -1931,8 +1931,6 @@ class Rac3Interface(GameInterface):
         for name in non_prog_weapon_data.keys():
             unlock_addr = non_prog_weapon_data[name].UNLOCK_ADDRESS
             ammo_addr = non_prog_weapon_data[name].AMMO_ADDRESS
-            xp_addr = non_prog_weapon_data[name].XP_ADDRESS
-            level_addr = non_prog_weapon_data[name].LEVEL_ADDRESS
             if self.UnlockItem[name].status:
                 if self.UnlockItem[name].unlock_delay:
                     self._write8(unlock_addr, 1)
@@ -1950,8 +1948,6 @@ class Rac3Interface(GameInterface):
                 # Prevent the player from using locked weapons and leveling them to accidentally break vendors
                 self._write8(unlock_addr, 0)
                 self._write32(ammo_addr, 0)
-                self._write32(xp_addr, 0)
-                self._write8(level_addr, UPGRADE_DICT[name][0])
 
         if self.equipped_item > 1 and self.UnlockItem[ITEM_NAME_FROM_ID[self.equipped_item]].status == 0:
             if self.last_used_1 == 0:

--- a/worlds/rac3/constants/data/address.py
+++ b/worlds/rac3/constants/data/address.py
@@ -27,6 +27,7 @@ SAVE_DATA: list[RAC3ADDRESSDATA] = [
     RAC3ADDRESSDATA((RAC3STATUS.CRYSTALS_CURRENT, CHECKTYPE.BYTE, 0)),
     *[RAC3ADDRESSDATA((weapon.AMMO_ADDRESS, CHECKTYPE.INT, weapon.AMMO)) for weapon in non_prog_weapon_data.values()],
     *[RAC3ADDRESSDATA((weapon.XP_ADDRESS, CHECKTYPE.INT, 0)) for weapon in non_prog_weapon_data.values()],
+    *[RAC3ADDRESSDATA((weapon.LEVEL_ADDRESS, CHECKTYPE.BYTE, weapon.ID)) for weapon in non_prog_weapon_data.values()],
     # Stored Fillers
     RAC3ADDRESSDATA((RAC3STATUS.BOLT_PACKS, CHECKTYPE.INT, 0)),
     RAC3ADDRESSDATA((RAC3STATUS.NANOTECH_EXP_PACKS, CHECKTYPE.INT, 0)),


### PR DESCRIPTION
Turns out that I forgot about the initial reset_file() call that will call weapon cycler with everything marked as "locked"; causing it to reset level and exp