### PR TITLE
RAC3: Refer to the new custom channel in the setup guide

### DIFF
--- a/worlds/rac3/docs/setup_en.md
+++ b/worlds/rac3/docs/setup_en.md
@@ -69,4 +69,4 @@ This section is for players who want to host a solo or multiplayer game.
 
 For common issues, check the [FAQ](https://github.com/Taoshix/Archipelago-RaC3/blob/staging/worlds/rac3/docs/frequently_asked_questions_Rac3_en.md).
 
-If you need further help, join the [Archipelago Discord](https://discord.gg/archipelago) and visit the `ratchet-and-clank-3` channel under the `Custom Games N-Z` channel category.
+If you need further help, join the [Archipelago Discord](https://discord.gg/archipelago) and visit the `#ratchet-and-clank-3` channel under the `Custom Games N-Z` channel category.

--- a/worlds/rac3/docs/setup_en.md
+++ b/worlds/rac3/docs/setup_en.md
@@ -69,4 +69,4 @@ This section is for players who want to host a solo or multiplayer game.
 
 For common issues, check the [FAQ](https://github.com/Taoshix/Archipelago-RaC3/blob/staging/worlds/rac3/docs/frequently_asked_questions_Rac3_en.md).
 
-If you need further help, join the [Archipelago Discord](https://discord.gg/archipelago) and visit the `[PS2] Ratchet and Clank 3: Up Your Arsenal` thread in the `future-game-design` forum channel (located at the bottom).
+If you need further help, join the [Archipelago Discord](https://discord.gg/archipelago) and visit the `ratchet-and-clank-3` channel under the `Custom Games N-Z` channel category.


### PR DESCRIPTION
## What does this PR do?
This PR changes the documentation to refer to the custom channel after moving there from the future game design thread.
