### PR TITLE
RAC3: Rework weapon_level_options into OptionSet

### DIFF
--- a/worlds/rac3/options/weapon_level_options.py
+++ b/worlds/rac3/options/weapon_level_options.py
@@ -1,21 +1,21 @@
 """This module contains options for Weapon Level locations"""
 
-from Options import Choice
+from Options import OptionSet
 from worlds.rac3.constants.options import RAC3OPTION
 
 
-class WeaponLevels(Choice):
+class WeaponLevels(OptionSet):
     """
     Determines whether weapon levels should be locations or not.
     -----------------------------------------------------------------------------------------------
-    Disable: No weapon levels are locations.
-    V5:      Only V5 weapon levels are locations.
-    All:     All weapon levels are locations (including V6, V7, V8 if ngplus_items are enabled).
+    All weapon levels can be locations (including V6, V7, V8 if ngplus_items are enabled).
+    Only the selected levels will give locations tied to them. To disable weapon level locations leave the brackets empty.
+    The valid keys are the following: V2, V3, V4, V5, V6, V7, V8
     -----------------------------------------------------------------------------------------------
     Note: If progressive weapons are enabled, leveling will be forced to manual leveling instead of automatic leveling.
     """
     display_name = RAC3OPTION.WEAPON_LEVEL_LOCATIONS
-    option_disable = 0
-    option_v5 = 1
-    option_all = 2
-    default = 1
+    valid_keys = frozenset({
+        "V2", "V3", "V4", "V5", "V6", "V7", "V8"
+    })
+    default = frozenset({"V2", "V3", "V4", "V5"})

--- a/worlds/rac3/regions.py
+++ b/worlds/rac3/regions.py
@@ -558,10 +558,8 @@ def should_skip_location(data: RAC3LOCATIONDATA, options: type[RaC3Options]) -> 
                 if options.armor_vendor.value == 0:
                     return True  # Skip all armor upgrade locations if armor upgrades are disabled
             case RAC3TAG.WEAPON_LEVEL:
-                if options.weapon_level_locations.value == 0:
+                if all(key not in loc for key in options.weapon_level_locations.value):
                     return True  # Skip all weapon level locations if weapon levels are disabled
-                if options.weapon_level_locations.value == 1 and "V5" not in loc:
-                    return True  # Skip all weapon level locations that are not V5 if weapon levels are set to V5 only
                 if options.ngplus_items.value == 0 and ("RY3N0" in loc or "V6" in loc or "V7" in loc or "V8" in loc):
                     return True  # Skip all weapon level locations that are V6 or higher if NG+ items are disabled
                 if options.one_hp_challenge.value.get(RAC3PLAYERTYPE.RATCHET, False) and "Shield Charger" in loc:

--- a/worlds/rac3/world.py
+++ b/worlds/rac3/world.py
@@ -209,7 +209,7 @@ class RaC3World(World):
             option_list.append(RAC3OPTION.ARMOR_VENDOR)
         if self.options.ship_vendor.value == 0:
             option_list.append(RAC3OPTION.SHIP_VENDOR)
-        if self.options.weapon_level_locations.value == 0:
+        if not self.options.weapon_level_locations.value:
             option_list.append(RAC3OPTION.WEAPON_LEVEL_LOCATIONS)
         if self.options.sewer_crystals.value < 3:
             option_list.append(RAC3OPTION.SEWER_CRYSTALS)


### PR DESCRIPTION
## What does this PR do?
This PR changes the weapon level up locations option into an OptionSet allowing for a more customizable option. Previously the player could only have either no locations, all 5 (or 8 depending on their NG+ items option) or V5 locations only. This had the side effect of not being able to play with only V1-V5 weapon level locations on NG with Omega weapons, because said weapons would have V6-V8 checks as well automatically. The option defaults to V2-V5 keys with all the possible options mentioned in the yaml description for ease of modifying. The option accounts for all the same edge cases as it's previous iteration (One HP - Shield Charger interaction, Automatic Weapon Leveling)
